### PR TITLE
CORS

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -23,6 +23,7 @@ func service() {
 
 	// Middleware
 	echoService.Use(middleware.Recover())
+	echoService.Use(middleware.CORSWithConfig(middleware.DefaultCORSConfig))
 
 	// Routes
 	echoService.GET("/swagger/*", echoSwagger.WrapHandler)


### PR DESCRIPTION
CORS was not enabled, but that was causing problems, so now we're adding the default CORS config, which allows everything:
![image](https://user-images.githubusercontent.com/34345435/104942481-83653280-5982-11eb-9355-c0ed2d85ea11.png)
