### PR TITLE
add temporary key and type to new benefits

### DIFF
--- a/benefit_info_en.json
+++ b/benefit_info_en.json
@@ -45,8 +45,8 @@
     "long_description": "# Ontario Child Care Subsidy \n* Lorem ipsum dolor sit amet \n## Curabitur feugiat, turpis a dignissim dictum \n* Praesent fermentum lectus ac vulputate suscipit  \n## Aliquam vehicula consectetur felis ac luctus \n* Praesent et sollicitudin felis, vitae lobortis sapien \n## Pellentesque consequat \n* Suspendisse ac posuere tortor, consequat imperdiet augue \n* Must have a permanant address \n* Must be a resident of Canada \n* Must be a Canadian Citizen \n### Vestibulum mollis in dolor in pretium \n* Class aptent taciti sociosqu ad litora torquent per conubia nostra, per inceptos himenaeos \n## Phasellus varius \n* Pellentesque consequat diam in rhoncus dapibus \n## Quisque tempus \n* Morbi sit amet varius mi, ut viverra lorem. \n## Duis vestibulum \n* Cras fringilla euismod ante sit amet consequat. \n## Donec rutrum \n* Donec ultrices ultricies ipsum, ut iaculis sapien euismod eget.",
     "related_benefits": [],
     "service_type": "External",
-    "benefit_type": "",
-    "benefit_key": "",
+    "benefit_type": "occs",
+    "benefit_key": "occs",
     "benefit_tags": [],
     "redirect_url": "ontario.ca/page/child-care-subsidies",
     "api_url": ""
@@ -58,8 +58,8 @@
     "long_description": "# Ontario Low Income Credit \n* Lorem ipsum dolor sit amet \n## Curabitur feugiat, turpis a dignissim dictum \n* Praesent fermentum lectus ac vulputate suscipit  \n## Aliquam vehicula consectetur felis ac luctus \n* Praesent et sollicitudin felis, vitae lobortis sapien \n## Pellentesque consequat \n* Suspendisse ac posuere tortor, consequat imperdiet augue \n* Must have a permanant address \n* Must be a resident of Canada \n* Must be a Canadian Citizen \n### Vestibulum mollis in dolor in pretium \n* Class aptent taciti sociosqu ad litora torquent per conubia nostra, per inceptos himenaeos \n## Phasellus varius \n* Pellentesque consequat diam in rhoncus dapibus \n## Quisque tempus \n* Morbi sit amet varius mi, ut viverra lorem. \n## Duis vestibulum \n* Cras fringilla euismod ante sit amet consequat. \n## Donec rutrum \n* Donec ultrices ultricies ipsum, ut iaculis sapien euismod eget.",
     "related_benefits": [],
     "service_type": "External",
-    "benefit_type": "",
-    "benefit_key": "",
+    "benefit_type": "olic",
+    "benefit_key": "olic",
     "benefit_tags": [],
     "redirect_url": "ontario.ca/page/low-income-workers-tax-credit",
     "api_url": ""

--- a/benefit_info_fr.json
+++ b/benefit_info_fr.json
@@ -45,8 +45,8 @@
     "long_description": "# [FR] Ontario Child Care Subsidy \n* Lorem ipsum dolor sit amet \n## Curabitur feugiat, turpis a dignissim dictum \n* Praesent fermentum lectus ac vulputate suscipit  \n## Aliquam vehicula consectetur felis ac luctus \n* Praesent et sollicitudin felis, vitae lobortis sapien \n## Pellentesque consequat \n* Suspendisse ac posuere tortor, consequat imperdiet augue \n* Must have a permanant address \n* Must be a resident of Canada \n* Must be a Canadian Citizen \n### Vestibulum mollis in dolor in pretium \n* Class aptent taciti sociosqu ad litora torquent per conubia nostra, per inceptos himenaeos \n## Phasellus varius \n* Pellentesque consequat diam in rhoncus dapibus \n## Quisque tempus \n* Morbi sit amet varius mi, ut viverra lorem. \n## Duis vestibulum \n* Cras fringilla euismod ante sit amet consequat. \n## Donec rutrum \n* Donec ultrices ultricies ipsum, ut iaculis sapien euismod eget.",
     "related_benefits": [],
     "service_type": "[FR] External",
-    "benefit_type": "",
-    "benefit_key": "",
+    "benefit_type": "occs",
+    "benefit_key": "occs",
     "benefit_tags": [],
     "redirect_url": "ontario.ca/page/child-care-subsidies",
     "api_url": ""
@@ -58,8 +58,8 @@
     "long_description": "# [FR] Ontario Low Income Credit \n* Lorem ipsum dolor sit amet \n## Curabitur feugiat, turpis a dignissim dictum \n* Praesent fermentum lectus ac vulputate suscipit  \n## Aliquam vehicula consectetur felis ac luctus \n* Praesent et sollicitudin felis, vitae lobortis sapien \n## Pellentesque consequat \n* Suspendisse ac posuere tortor, consequat imperdiet augue \n* Must have a permanant address \n* Must be a resident of Canada \n* Must be a Canadian Citizen \n### Vestibulum mollis in dolor in pretium \n* Class aptent taciti sociosqu ad litora torquent per conubia nostra, per inceptos himenaeos \n## Phasellus varius \n* Pellentesque consequat diam in rhoncus dapibus \n## Quisque tempus \n* Morbi sit amet varius mi, ut viverra lorem. \n## Duis vestibulum \n* Cras fringilla euismod ante sit amet consequat. \n## Donec rutrum \n* Donec ultrices ultricies ipsum, ut iaculis sapien euismod eget.",
     "related_benefits": [],
     "service_type": "[FR] External",
-    "benefit_type": "",
-    "benefit_key": "",
+    "benefit_type": "olic",
+    "benefit_key": "olic",
     "benefit_tags": [],
     "redirect_url": "ontario.ca/page/low-income-workers-tax-credit",
     "api_url": ""


### PR DESCRIPTION
New benefits do not have benefit_key or benefit_type. The frontend uses these values as unique IDs for components on the page and so without them, errors fill the console. This is a temporary fix until we have the real IDs and types decided on.